### PR TITLE
Force character to make test robust to R version

### DIFF
--- a/tests/testthat/test-asDistribution.R
+++ b/tests/testthat/test-asDistribution.R
@@ -34,7 +34,7 @@ test_that("as.Distribution works with cdf expected", {
   wd <- as.Distribution(mat, fun = "cdf")
 
   expect_R6_class(wd, "VectorDistribution")
-  expect_equal(unique(wd$modelTable$Distribution), "WeightedDiscrete")
+  expect_equal(as.character(unique(wd$modelTable$Distribution)), "WeightedDiscrete")
 
   expect_equal(
     vapply(wd$getParameterValue("x"), identity, numeric(10)),


### PR DESCRIPTION
Identically motivated to b6e6b160fcab8e57461015fde39dbb6e30a37ac5